### PR TITLE
Add FastAPI backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 uvicorn main:app --reload
 ```
+See `mcp-server/README.md` for endpoint details and additional usage notes.
 
 ### Frontend (SvelteKit UI)
 ```bash

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,19 @@
+# MCP Server — FastAPI Backend
+
+This folder contains the backend implementation for the Model Context Protocol (MCP). It exposes HTTP endpoints used by the SvelteKit frontend and external tools.
+
+## 📌 Endpoints
+
+- `POST /chat` — Accepts a chat message and returns a placeholder response. More routes will be added as the protocol evolves.
+
+## 🚀 Usage
+
+```bash
+cd mcp-server
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+The server runs on `http://localhost:8000` by default.

--- a/mcp-server/main.py
+++ b/mcp-server/main.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+class ChatRequest(BaseModel):
+    message: str
+
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    """Placeholder chat endpoint."""
+    return {"response": "Not implemented yet"}

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- implement basic FastAPI app with placeholder `/chat` endpoint
- document server endpoints and usage instructions
- list backend requirements
- update main README with server setup notes

## Testing
- `python -m py_compile mcp-server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_686f3d7fbeec8325a55377b62a8ff5c2