### PR TITLE
Add agent examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This tool is designed for **context-first interaction with OpenAI models**, spec
 codex-assistant/
 ├── mcp-server/       # FastAPI backend with MCP endpoints
 ├── sveltekit-ui/     # Frontend chat interface (SvelteKit)
-├── agents/           # YAML agent definitions
+├── agents/           # YAML agent definitions (see `agents/agents.yaml`)
 ├── summaries/        # Cached summaries of large files
 └── README.md         # This file — high-level context
 ```
@@ -54,3 +54,9 @@ This README is intended to help Codex:
 - Locate summary caches used for planning
 
 This file should be included in every model context request involving strategic or high-level planning.
+
+## ✍️ Customizing Agents
+
+Edit `agents/agents.yaml` to add or adjust agent personalities. Each entry defines
+an `id`, `name`, `model`, `instructions`, and a `context` list. Update these fields
+to tailor how the assistant operates.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,6 +1,6 @@
 # Agent Configuration — Codex Assistant
 
-This folder contains `agents.yaml`, which defines model instructions, personality types, and context preferences for Codex or OpenAI models.
+This folder contains `agents.yaml`, which defines model instructions, personality types, and context preferences for Codex or OpenAI models. The file lives at `agents/agents.yaml`.
 
 Each agent is used to focus the assistant's behavior in a specific way (e.g., reviewer, strategist, debugger).
 
@@ -30,3 +30,10 @@ context:
   - type: repo_summary
     path: ~/Projects/EleusisAI
 ```
+
+## 🛠️ Customizing Agents
+
+Edit `agents.yaml` to add new personalities or adjust existing ones. For each entry,
+specify an `id`, user-friendly `name`, target `model`, multi-line `instructions`,
+and a `context` list describing which repo data to load. Save your changes and
+restart the backend to apply them.

--- a/agents/agents.yaml
+++ b/agents/agents.yaml
@@ -1,0 +1,15 @@
+- id: strategist
+  name: Project Strategist
+  model: gpt-4
+  instructions: >
+    Help plan the future of the codebase. Avoid specific code edits; focus on patterns, refactors, and abstractions.
+  context:
+    - type: repo_summary
+      path: summaries
+- id: reviewer
+  name: Code Reviewer
+  model: gpt-4
+  instructions: >
+    Provide thorough reviews of proposed changes. Note code quality issues and suggest improvements.
+  context:
+    - type: diff


### PR DESCRIPTION
## Summary
- add `agents/agents.yaml` with strategist and reviewer examples
- document where to customize agents

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f3daa09f48325a3f2950ab0020bdf