### PR TITLE
Add summary CLI

### DIFF
--- a/summaries/README.md
+++ b/summaries/README.md
@@ -32,3 +32,14 @@ This folder gives Codex:
   "timestamp": "2025-07-10T10:00:00Z"
 }
 ```
+
+## 🚀 Usage
+
+Generate a summary by running the helper script with a target file:
+
+```bash
+python summary.py path/to/large_file.js > path/to/large_file.summary.json
+```
+
+The script prints a JSON object matching the format above, which you can redirect
+to a file for later use.

--- a/summaries/summary.py
+++ b/summaries/summary.py
@@ -1,0 +1,41 @@
+import sys
+import os
+import json
+from datetime import datetime, timezone
+
+
+def summarize(text: str, max_words: int = 40) -> tuple[int, str]:
+    """Return token count and simple summary from text.
+
+    Tokens are approximated using whitespace word count.
+    The summary is the first `max_words` words of the file.
+    """
+    words = text.strip().split()
+    token_count = len(words)
+    summary = " ".join(words[:max_words])
+    return token_count, summary
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: python summary.py <file>", file=sys.stderr)
+        sys.exit(1)
+
+    path = sys.argv[1]
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    tokens, summary = summarize(content)
+
+    result = {
+        "file": os.path.basename(path),
+        "tokens": tokens,
+        "summary": summary,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple summary helper to produce cached summaries
- document usage for the new CLI in `summaries/README.md`

## Testing
- `python summaries/summary.py summaries/README.md | head`

------
https://chatgpt.com/codex/tasks/task_e_686f3daf324c83258e86b280d7c25749