### PR TITLE
Add simple chat UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ cd sveltekit-ui
 npm install
 npm run dev
 ```
+Open `http://localhost:5173` to interact with the chat interface.
 
 ---
 

--- a/sveltekit-ui/README.md
+++ b/sveltekit-ui/README.md
@@ -1,6 +1,11 @@
-# sv
+# SvelteKit UI
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+Frontend interface for the Codex Assistant. This project uses SvelteKit and Tailwind CSS.
+
+## Features
+
+- Simple chat panel that sends messages to the MCP backend at `http://localhost:8000/chat`.
+- Tailwind styling for quick prototyping.
 
 ## Creating a project
 

--- a/sveltekit-ui/src/lib/Chat.svelte
+++ b/sveltekit-ui/src/lib/Chat.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+
+  interface Message {
+    role: 'user' | 'assistant';
+    content: string;
+  }
+
+  let messages: Message[] = [];
+  let input = '';
+
+  async function sendMessage() {
+    if (!input.trim()) return;
+    const userMessage: Message = { role: 'user', content: input };
+    messages = [...messages, userMessage];
+    const res = await fetch('http://localhost:8000/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: input })
+    });
+    input = '';
+    if (res.ok) {
+      const data = await res.json();
+      const assistantMessage: Message = {
+        role: 'assistant',
+        content: data.response
+      };
+      messages = [...messages, assistantMessage];
+    } else {
+      messages = [...messages, { role: 'assistant', content: 'Error contacting server' }];
+    }
+  }
+</script>
+
+<div class="flex flex-col h-full">
+  <div class="flex-1 overflow-y-auto p-4 space-y-2">
+    {#each messages as msg}
+      <div class="p-2 rounded-md" class:ml-auto={msg.role === 'user'} class:bg-blue-100={msg.role === 'user'} class:bg-gray-100={msg.role === 'assistant'}>
+        {msg.content}
+      </div>
+    {/each}
+  </div>
+  <form class="flex p-4 gap-2" on:submit|preventDefault={sendMessage}>
+    <input class="border flex-1 p-2 rounded" bind:value={input} placeholder="Type a message" />
+    <button class="bg-blue-500 text-white px-4 py-2 rounded" type="submit">Send</button>
+  </form>
+</div>
+

--- a/sveltekit-ui/src/lib/index.ts
+++ b/sveltekit-ui/src/lib/index.ts
@@ -1,1 +1,1 @@
-// place files you want to import through the `$lib` alias in this folder.
+export { default as Chat } from './Chat.svelte';

--- a/sveltekit-ui/src/routes/+page.svelte
+++ b/sveltekit-ui/src/routes/+page.svelte
@@ -1,2 +1,8 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+  import Chat from '$lib/Chat.svelte';
+</script>
+
+<div class="flex flex-col h-screen">
+  <header class="p-4 bg-gray-800 text-white text-lg">Codex Chat</header>
+  <Chat class="flex-1" />
+</div>


### PR DESCRIPTION
## Summary
- implement `Chat.svelte` component with Tailwind styles
- update home page to show the chat panel
- export `Chat` from `$lib`
- document the chat interface in the root and UI READMEs

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*

------
https://chatgpt.com/codex/tasks/task_e_686f45e9b9c88325a817b0990dac0170