### PR TITLE
Add OpenAI integration to MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 # SvelteKit build outputs
 sveltekit-ui/build/
 sveltekit-ui/.svelte-kit/
+.env

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=sk-your-key
+

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -4,7 +4,7 @@ This folder contains the backend implementation for the Model Context Protocol (
 
 ## 📌 Endpoints
 
-- `POST /chat` — Accepts a chat message and returns a placeholder response. More routes will be added as the protocol evolves.
+- `POST /chat` — Accepts a chat message and returns a response from OpenAI. More routes will be added as the protocol evolves.
 
 ## 🚀 Usage
 
@@ -17,3 +17,12 @@ uvicorn main:app --reload
 ```
 
 The server runs on `http://localhost:8000` by default.
+
+## 🔑 API Key
+
+Set `OPENAI_API_KEY` in your environment so the server can call OpenAI. You can
+copy `.env.example` to `.env` and add your key:
+
+```bash
+cp .env.example .env
+```

--- a/mcp-server/main.py
+++ b/mcp-server/main.py
@@ -1,12 +1,22 @@
+import os
+
+import openai
 from fastapi import FastAPI
 from pydantic import BaseModel
 
 app = FastAPI()
+
+openai.api_key = os.environ.get("OPENAI_API_KEY")
 
 class ChatRequest(BaseModel):
     message: str
 
 @app.post("/chat")
 async def chat(request: ChatRequest):
-    """Placeholder chat endpoint."""
-    return {"response": "Not implemented yet"}
+    """Forward the message to OpenAI and return its reply."""
+    completion = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": request.message}],
+    )
+    answer = completion.choices[0].message["content"]
+    return {"response": answer}

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+openai


### PR DESCRIPTION
## Summary
- integrate OpenAI in `mcp-server/main.py`
- depend on `openai`
- document `/chat` OpenAI behaviour and API key usage
- ignore `.env` files and add `.env.example`

## Testing
- `python -m py_compile mcp-server/main.py`
- `python -m py_compile summaries/summary.py`


------
https://chatgpt.com/codex/tasks/task_e_686f465c61c883259e4f9a42dadaee94