### PR TITLE
Fix OpenAI client usage

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -23,6 +23,9 @@ The server runs on `http://localhost:8000` by default.
 Set `OPENAI_API_KEY` in your environment so the server can call OpenAI. You can
 copy `.env.example` to `.env` and add your key:
 
+The server initializes an `openai.OpenAI` client using this key when handling
+requests.
+
 ```bash
 cp .env.example .env
 ```

--- a/mcp-server/main.py
+++ b/mcp-server/main.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 app = FastAPI()
 
-openai.api_key = os.environ.get("OPENAI_API_KEY")
+client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
 class ChatRequest(BaseModel):
     message: str
@@ -14,9 +14,9 @@ class ChatRequest(BaseModel):
 @app.post("/chat")
 async def chat(request: ChatRequest):
     """Forward the message to OpenAI and return its reply."""
-    completion = openai.ChatCompletion.create(
+    response = client.chat.completions.create(
         model="gpt-4",
         messages=[{"role": "user", "content": request.message}],
     )
-    answer = completion.choices[0].message["content"]
+    answer = response.choices[0].message.content
     return {"response": answer}


### PR DESCRIPTION
## Summary
- switch FastAPI backend to new `openai.OpenAI` client
- note client initialization in backend README

## Testing
- `python -m py_compile mcp-server/main.py`

------
https://chatgpt.com/codex/tasks/task_e_686f49e6d4f88325b9d46f23f08b0f8e