### PR TITLE
Switch to AsyncOpenAI client

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -23,8 +23,8 @@ The server runs on `http://localhost:8000` by default.
 Set `OPENAI_API_KEY` in your environment so the server can call OpenAI. You can
 copy `.env.example` to `.env` and add your key:
 
-The server initializes an `openai.OpenAI` client using this key when handling
-requests.
+The server initializes an `openai.AsyncOpenAI` client which automatically reads
+this key when handling requests.
 
 ```bash
 cp .env.example .env

--- a/mcp-server/main.py
+++ b/mcp-server/main.py
@@ -1,6 +1,6 @@
 import os
 from dotenv import load_dotenv
-import openai
+from openai import AsyncOpenAI
 from fastapi import FastAPI
 from pydantic import BaseModel
 
@@ -8,7 +8,7 @@ load_dotenv()
 
 app = FastAPI()
 
-client = openai.OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+client = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
 class ChatRequest(BaseModel):
     message: str
@@ -16,7 +16,7 @@ class ChatRequest(BaseModel):
 @app.post("/chat")
 async def chat(request: ChatRequest):
     """Forward the message to OpenAI and return its reply."""
-    response = client.chat.completions.create(
+    response = await client.chat.completions.create(
         model="gpt-4",
         messages=[{"role": "user", "content": request.message}],
     )


### PR DESCRIPTION
## Summary
- update backend to use `AsyncOpenAI`
- document new async client usage in the backend README

## Testing
- `python -m py_compile mcp-server/main.py`

------
https://chatgpt.com/codex/tasks/task_e_686f52505d3c83259b8e49da9ae05637