### PR TITLE
Fix layout slot syntax

### DIFF
--- a/sveltekit-ui/README.md
+++ b/sveltekit-ui/README.md
@@ -6,6 +6,7 @@ Frontend interface for the Codex Assistant. This project uses SvelteKit and Tail
 
 - Simple chat panel that sends messages to the MCP backend at `http://localhost:8000/chat`.
 - Tailwind styling for quick prototyping.
+- Global styles from `src/app.css` are imported in `src/routes/+layout.svelte`.
 
 ## Creating a project
 

--- a/sveltekit-ui/src/routes/+layout.svelte
+++ b/sveltekit-ui/src/routes/+layout.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import '../app.css';
-
-	let { children } = $props();
+  import '../app.css';
 </script>
 
-{@render children()}
+<slot />


### PR DESCRIPTION
## Summary
- switch to `<slot />` syntax in the SvelteKit layout
- document global CSS import in UI README

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run check` *(fails: svelte-kit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f5301f59c832593b4094d2fa9b992