### PR TITLE
Update frontend README

### DIFF
--- a/sveltekit-ui/README.md
+++ b/sveltekit-ui/README.md
@@ -1,11 +1,14 @@
 # SvelteKit UI
 
-Frontend interface for the Codex Assistant. This project uses SvelteKit and Tailwind CSS.
+Frontend interface for the Codex Assistant. This project uses SvelteKit and enhanced Tailwind CSS.
 
 ## Features
 
-- Simple chat panel that sends messages to the MCP backend at `http://localhost:8000/chat`.
-- Tailwind styling for quick prototyping.
+- Simple chat panel that sends messages to the MCP backend defined by `VITE_BACKEND_URL`.
+- Enhanced Tailwind styling for a cleaner interface.
+
+The chat layout now uses bubble-style messages with alternating colors for user
+and assistant responses, providing clearer visual separation.
 
 ## Creating a project
 
@@ -17,6 +20,12 @@ npx sv create
 
 # create a new project in my-app
 npx sv create my-app
+```
+
+Set `VITE_BACKEND_URL` in a `.env` file to control which MCP server the UI uses. Example:
+
+```bash
+VITE_BACKEND_URL=http://localhost:8000
 ```
 
 ## Developing

--- a/sveltekit-ui/src/lib/Chat.svelte
+++ b/sveltekit-ui/src/lib/Chat.svelte
@@ -12,7 +12,8 @@
     if (!input.trim()) return;
     const userMessage: Message = { role: 'user', content: input };
     messages = [...messages, userMessage];
-    const res = await fetch('http://localhost:8000/chat', {
+    const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000';
+    const res = await fetch(`${backendUrl}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ message: input })


### PR DESCRIPTION
## Summary
- document improved Tailwind design in `sveltekit-ui`
- note usage of `VITE_BACKEND_URL`
- wire chat UI to read `VITE_BACKEND_URL` environment variable

## Testing
- `npm run lint` *(fails: Cannot find package)*
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f530d6bb88325a3bf8bd48d4fd7b7