### PR TITLE
Use env variable for backend URL

### DIFF
--- a/sveltekit-ui/.env
+++ b/sveltekit-ui/.env
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=http://localhost:8000

--- a/sveltekit-ui/README.md
+++ b/sveltekit-ui/README.md
@@ -4,7 +4,7 @@ Frontend interface for the Codex Assistant. This project uses SvelteKit and Tail
 
 ## Features
 
-- Simple chat panel that sends messages to the MCP backend at `http://localhost:8000/chat`.
+- Simple chat panel that sends messages to the MCP backend defined in the `VITE_BACKEND_URL` environment variable.
 - Tailwind styling for quick prototyping.
 
 ## Creating a project
@@ -41,3 +41,7 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## Environment variables
+
+Create a `.env` file in this folder and define `VITE_BACKEND_URL` to point at your MCP backend. The default used in development is `http://localhost:8000`.

--- a/sveltekit-ui/src/lib/Chat.svelte
+++ b/sveltekit-ui/src/lib/Chat.svelte
@@ -8,11 +8,13 @@
   let messages: Message[] = [];
   let input = '';
 
+  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000';
+
   async function sendMessage() {
     if (!input.trim()) return;
     const userMessage: Message = { role: 'user', content: input };
     messages = [...messages, userMessage];
-    const res = await fetch('http://localhost:8000/chat', {
+    const res = await fetch(`${backendUrl}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ message: input })


### PR DESCRIPTION
## Summary
- configure `VITE_BACKEND_URL` in the UI
- read this variable in `Chat.svelte`
- document the new setting in the SvelteKit README

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run check` *(fails: svelte-kit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f52f7b0c083259a039b566024aec7